### PR TITLE
Feat: Implement basic array support

### DIFF
--- a/datosEjemplos.js
+++ b/datosEjemplos.js
@@ -198,8 +198,35 @@ FinAlgoritmo`,
 
     Escribir "Te llamas ", nombre, ", tienes ", edad, " años y vives en ", ciudad, "."
 FinAlgoritmo`,
-    arrays: `Algoritmo EjemploArregloSimple
-    Escribir "Ejemplo de Arreglos (a implementar en Fase posterior)"
+    arrays_basico: `Algoritmo EjemploArreglosBasico
+    Dimension notas[3] // Se declara como 'entero' por defecto
+    Definir i Como Entero
+
+    Escribir "Cargando notas (numéricas inicialmente):"
+    Para i <- 1 Hasta 3 Hacer
+        notas[i] <- i * 2 // Asigna 2, 4, 6
+        Escribir "Nota ", i, ": ", notas[i]
+    FinPara
+
+    Escribir "Asignando un texto a notas[2]. El arreglo se convertirá a Cadena."
+    notas[2] <- "Sobresaliente" // Dinámicamente cambia el tipo de 'notas' a Cadena
+
+    Escribir "Mostrando todas las notas (ahora como cadenas):"
+    Para i <- 1 Hasta 3 Hacer
+        Escribir "Elemento ", i, ": ", notas[i]
+    FinPara
+
+    Escribir "--- Ejemplo con arreglo definido con tipo ---"
+    Definir nombres Como Cadena[2]
+    nombres[1] <- "Ana"
+    nombres[2] <- "Juan"
+    Escribir "Nombres: ", nombres[1], ", ", nombres[2]
+
+    Definir edades Como Entero[2]
+    edades[1] <- 20
+    //edades[2] <- "treinta" // Esto debería dar error de tipo
+    edades[2] <- 30
+    Escribir "Edades: ", edades[1], ", ", edades[2]
 FinAlgoritmo`,
     mod_example: `Algoritmo ModuloEjemplo
 	Definir N, M, Resultado Como Real


### PR DESCRIPTION
This commit introduces fundamental array functionalities into the interpreter:

- **Array Declaration**:
    - Handles `Dimension nombre[dims]` and `Dimensionar nombre[dims]`. Arrays declared this way default to `baseType: 'entero'` and elements are initialized to 0.
    - Extends `Definir var Como Tipo[dims]` to declare typed arrays, initialized with type-specific default values.
    - `inicializarArray` helper creates 1-based indexed JS arrays.

- **Array Element Assignment (LHS)**:
    - `handleAsignacion` now supports `arr[idx1, idx2,...] <- valor` and `arr[idx1, idx2,...] = valor`.
    - Includes index expression evaluation and bounds checking.
    - Implements PSeInt's dynamic typing for arrays declared with `Dimension`:
        - If a string is assigned to an element of an 'entero' array, the array's `baseType` changes to 'cadena'.
        - A new helper, `convertirElementosArrayAString`, converts all existing numeric elements to strings upon such a type change.

- **Array Element Access (RHS)**:
    - `evaluarExpresion` is updated for more robust parsing and validation of array element access like `arr[idx1, idx2,...]` when it's the direct expression being evaluated.

- **String Elements**: Supported through typed 'cadena' arrays and the dynamic type change mechanism.

- **New Example**: Added `EjemploArreglosBasico` to `datosEjemplos.js` to demonstrate these features.