### PR TITLE
Fix: Correctly parse function name and parameters in SubProceso defin…

### DIFF
--- a/evaluadorExpresiones.js
+++ b/evaluadorExpresiones.js
@@ -105,7 +105,8 @@ Webgoritmo.Expresiones.tokenize = function(exprStr) {
         { type: 'OPERATOR_LTE', regex: /<=|menor o igual que/iy },
         { type: 'OPERATOR_GTE', regex: />=|mayor o igual que/iy },
         { type: 'OPERATOR_NEQ', regex: /<>|!=|distinto de/iy }, // != is common PSeInt extension
-        { type: 'OPERATOR_EQ', regex: /==|=igual que/iy }, // PSeInt uses single '=' for comparison, '==' also for robustness
+        // Includes single '=' for comparison, after multi-char operators like ==, <=, >=
+        { type: 'OPERATOR_EQ', regex: /==|=igual que|=/iy },
         { type: 'OPERATOR_LT', regex: /<|menor que/iy },
         { type: 'OPERATOR_GT', regex: />|mayor que/iy },
 


### PR DESCRIPTION
…itions

Updated `parseDefinicionSubProceso` to use the correct regex capture group indices for extracting the function name (group 2) and parameters string (group 3).

This resolves a critical bug where sub-processes were not being correctly defined and stored, leading to failures in function calls and errors like 'Variable de retorno no definida' (e.g., 'sumaAux no definida') because the function definition itself was flawed.